### PR TITLE
Remove abbreviation in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Algolia API Clients - Specs & CTS
+# Algolia API Clients - Specs & common test suite
 
 This repository serves as a technical documentation of the public API of the
 Algolia API Clients. It covers both the public API (methods, functions, etc.)


### PR DESCRIPTION
I was reading this and wondering what it meant. If it’s written in full that issue isn’t necessary