### PR TITLE
fix: add delete_personalization_profile_response spec

### DIFF
--- a/api-client-specifications/personalization_api.md
+++ b/api-client-specifications/personalization_api.md
@@ -14,7 +14,7 @@ interface personalization_client {
     return get_personalization_profile_response
 
     function delete_personalization_profile(userToken: string, opts: request_options)
-    return void
+    return delete_personalization_profile_response
 
     function get_personalization_strategy(opts: request_options)
     return get_personalization_strategy_response
@@ -56,6 +56,13 @@ struct get_personalization_profile_response {
   userToken: string,
   lastEventAt: datetime,
   scores: object
+}
+```
+
+```java
+struct delete_personalization_profile_response {
+  userToken: string,
+  deletedUntil: datetime
 }
 ```
 


### PR DESCRIPTION
Deleting a user profile actually returns a response: https://www.algolia.com/doc/rest-api/personalization/#delete-a-user-profile